### PR TITLE
Syntax error fix

### DIFF
--- a/src/SkulptWrapper/skulptWrapper.js
+++ b/src/SkulptWrapper/skulptWrapper.js
@@ -1,6 +1,9 @@
 /* eslint-disable no-unused-vars */
 import GlobalsParser from './skulptGlobalsParser';
 
+// instantiate the globals since undefined in JavaScript is a atrocious
+window.Sk.globals = {};
+
 //------------------------------Builtin functions-------------------------------
 function builtinRead(x) {
   if (window.Sk.builtinFiles === undefined || window.Sk.builtinFiles['files'][x] === undefined)


### PR DESCRIPTION
Quick dirty fix for the problem where only the first time the program runs with a syntax error crashes the website

the problem was caused by uninitialized `Sk.globals`