### PR TITLE
Update breakpoints immediately after change

### DIFF
--- a/src/Components/CodeBox.js
+++ b/src/Components/CodeBox.js
@@ -114,7 +114,10 @@ const CodeBox = ({
           setEditor(() => _editor);
         }}
         onBeforeChange={(_editor, data, value) => {
-          if (data.text[0] != '\t') setCode(value);
+          if (data.text[0] != '\t') {
+            setCode(value);
+            update_breakpoints(_editor);
+          }
         }}
         onKeyDown={(_editor, event) => {
           if (event.key === 'Tab') {


### PR DESCRIPTION
* a small bugfix that fixes a problem where breakpoints can sometimes be moved to the wrong row, and only correctly renders again after a change has been made to the code.