### PR TITLE
start step at first code line

### DIFF
--- a/src/Pages/Home.js
+++ b/src/Pages/Home.js
@@ -71,8 +71,13 @@ const Home = () => {
   };
 
   const step_callback = (prog) => {
+    const first_row = first_row_of_code();
     if (!stepped) {
-      stop_at(prog);
+      if (line === -1) {
+        stop_at(prog, first_row);
+      } else {
+        stop_at(prog);
+      }
       return;
     }
 


### PR DESCRIPTION
solves the bugg: if the code begins with comments they get highlighted during step as if they were "runnable" 