### PR TITLE
Line marker overlaps line numbers fix

### DIFF
--- a/src/Components/CodeBox.css
+++ b/src/Components/CodeBox.css
@@ -15,13 +15,23 @@
 }
 
 .breakpoints{
-  width: 14px;
+  width: 13px;
   justify-content: center;
-  margin: 2px;
+  padding: 2px;
 }
 
-.CodeMirror-linenumber{
-  padding-right: 4px;
+.CodeMirror-linenumbers{
+  padding-right: 2px !important
+}
+
+.CodeMirror-gutter-elt{
+  padding: 2px !important;
+  text-align: right;
+}
+
+.lineMarker{
+  width: 16px;
+  padding: 2px;
 }
 
 .CodeMirror-focused { border: 3px solid blue; outline-offset: 1px }


### PR DESCRIPTION
Small css changes to fix problem with line marker overlapping line numbers when line > 9