### PR TITLE
Error handling

### DIFF
--- a/src/features/visual-box/VisualBox.js
+++ b/src/features/visual-box/VisualBox.js
@@ -9,7 +9,7 @@ import styles from 'src/features/visual-box//VisualBox.module.css';
 
 import generate_dot from './dotGenerator';
 
-const VisualBox = ({ data, colors, share_methods }) => {
+const VisualBox = ({ data, colors, share_methods, restart }) => {
   const [graph, setGraph] = useState({ dot: 'graph {}' });
   const [ariaLabel, setAriaLabel] = useState('');
   const [zoomedIn, setZoomedIn] = useState(false);
@@ -21,9 +21,13 @@ const VisualBox = ({ data, colors, share_methods }) => {
   };
 
   useEffect(() => {
-    const dot = generate_dot(data, colors);
-    setGraph(dot);
-    setAriaLabel(set_text(data.objects, data.variables));
+    try {
+      const dot = generate_dot(data, colors);
+      setGraph(dot);
+      setAriaLabel(set_text(data.objects, data.variables));
+    } catch (e) {
+      restart();
+    }
   }, [data, colors]);
 
   useEffect(() => {

--- a/src/features/visual-box/dotGenerator.js
+++ b/src/features/visual-box/dotGenerator.js
@@ -59,6 +59,13 @@ const generate_dot = (data, colors) => {
       set_collection_object(o, '{', '}');
     } else {
       // immutables
+      if (!o.value) {
+        // if we want more detailed error message
+        const error = new Error('Parse Exception');
+        error.object = o;
+        error.code = `Value is undefined`;
+        throw error;
+      }
       let label = o.value.toString();
       if (o.info.type === 'string') {
         label = '"&#34;' + label + '&#34;"';

--- a/src/pages/About.js
+++ b/src/pages/About.js
@@ -70,7 +70,7 @@ const About = () => {
           <li>Many iterations will make the website slow.</li>
           <li>Only Python 3.7.3 grammar is supported.</li>
           <li>A few Python libraries are supported.</li>
-          <li>Debugger is unable to suspend correctly when importing Python modules.</li>
+          <li>Debugger is unable to step correctly when importing some Python modules.</li>
         </ul>
         <h2 className={styles.Title}>Special Thanks</h2>
         <h3 className={styles.SubTitle}> Skulpt </h3>

--- a/src/pages/About.js
+++ b/src/pages/About.js
@@ -70,6 +70,7 @@ const About = () => {
           <li>Many iterations will make the website slow.</li>
           <li>Only Python 3.7.3 grammar is supported.</li>
           <li>A few Python libraries are supported.</li>
+          <li>Debugger is unable to suspend correctly when importing Python modules.</li>
         </ul>
         <h2 className={styles.Title}>Special Thanks</h2>
         <h3 className={styles.SubTitle}> Skulpt </h3>

--- a/src/pages/Home.js
+++ b/src/pages/Home.js
@@ -95,10 +95,10 @@ const Home = () => {
     setLocals(locals);
   };
 
-  const restart_callback = (prog, run = false) => {
+  const restart_callback = async (prog = code) => {
     setLocked(false);
     setError(false);
-    skulpt.restart(prog, clear_visuals, run);
+    skulpt.restart(prog, clear_visuals, false);
   };
 
   const run_callback = (prog) => {
@@ -232,7 +232,12 @@ const Home = () => {
           <OutputBox output={output} output_box_ref={output_box_ref} />
         </div>
         <div className={styles['Visual-box']} tabIndex={0}>
-          <VisualBox data={globals} colors={graph_colors} share_methods={share_methods} />
+          <VisualBox
+            data={globals}
+            colors={graph_colors}
+            share_methods={share_methods}
+            restart={restart_callback}
+          />
         </div>
       </div>
     </div>

--- a/src/pages/Home.js
+++ b/src/pages/Home.js
@@ -95,7 +95,7 @@ const Home = () => {
     setLocals(locals);
   };
 
-  const restart_callback = async (prog = code) => {
+  const restart_callback = (prog = code) => {
     setLocked(false);
     setError(false);
     skulpt.restart(prog, clear_visuals, false);

--- a/src/skulpt-wrapper/skulptParser.js
+++ b/src/skulpt-wrapper/skulptParser.js
@@ -108,20 +108,8 @@ const create_object = (objects, js_object, class_names) => {
    * @returns The parsed values from the class
    */
   const parse_class_values = (js_object) => {
+    const dunder_pattern = /^(__[a-zA-Z0-9_.-]*__)$/;
     const irrelevant_skulpt_attributes = [
-      'tp$name',
-      'ob$type',
-      '__init__',
-      '__module__',
-      'hp$type',
-      '$r',
-      'tp$setattr',
-      'tp$str',
-      'tp$length',
-      'tp$call',
-      'tp$getitem',
-      'tp$setitem',
-      'tp$getattr',
       // The name 'constructor' seems to be reserved in Skulpt which only appears
       // when inheritance is used. If a user-defined function in a class is named
       // 'constructor' then it will be named 'constructor_$rw$' instead
@@ -140,9 +128,12 @@ const create_object = (objects, js_object, class_names) => {
       if (
         // Skip if an instance variable is shadowing the class variable
         instance_variables_names.has(key) ||
+        // skulpt attributes
         irrelevant_skulpt_attributes.includes(key) ||
+        key.includes('$') ||
+        dunder_pattern.test(key) ||
         // Skip functions declared inside of a class
-        Object.getPrototypeOf(value).tp$name == 'function'
+        value instanceof window.Sk.builtin.func
       )
         continue;
 
@@ -159,7 +150,7 @@ const create_object = (objects, js_object, class_names) => {
   let obj = {
     id: uuidv4(),
     value: null,
-    info: js_object?.hp$type // check if it's class or not
+    info: js_object?.__class__ // check if it's class or not
       ? {
           type: 'class',
           class_name: js_object.tp$name

--- a/src/skulpt-wrapper/skulptParser.js
+++ b/src/skulpt-wrapper/skulptParser.js
@@ -150,14 +150,15 @@ const create_object = (objects, js_object, class_names) => {
   let obj = {
     id: uuidv4(),
     value: null,
-    info: js_object?.__class__ // check if it's class or not
-      ? {
-          type: 'class',
-          class_name: js_object.tp$name
-        }
-      : {
-          type: retrieve_full_type_name(js_object.tp$name)
-        },
+    info:
+      class_names.includes(js_object.tp$name) || js_object?.hp$type // check if it's class or not
+        ? {
+            type: 'class',
+            class_name: js_object.tp$name
+          }
+        : {
+            type: retrieve_full_type_name(js_object.tp$name)
+          },
     js_object: js_object
   };
   objects.push(obj);


### PR DESCRIPTION
Made some changes here and there to make the LearnyPy less prone to errors. For instance the following code snippet didn't work before (when you run the entire program at once)
```python
from collections import Counter
inventory = Counter()
loot = {"sword": 1, "bread": 3}
inventory.update(loot)
print(inventory)
```

Also added a try catch for dotGenerator so it doesn't crasch the web application. Tried writing a custom error message to the outputbox but was unable to since Skulpt was overwriting my message with some output that isn't really helpful for the user. Maybe someone else can have a look at it. My approach was to pass an extra parameter `output_text` to `restart_callback()` that by default has an empty string, which is later passed on to restart: `skulpt.restart(prog, () => clear_visuals(output_text), false);`.  Then I modified the promise in skulpt.restart to this:

```javascript
promise
  .then(this.debugger.success.bind(this.debugger), this.debugger.error.bind(this.debugger))
  .finally(() => {
    // call the callback function if it is a function
    if (typeof callback === 'function') {
      callback();
    }
  });
```
Even with the `finally(...` the `debugger.error` still overwrites the custom message passed in the callback function. 

I'm also pretty sure that the issue with imports won't be easy to fix. Skulpt even state [here ](https://github.com/skulpt/skulpt/blob/master/doc/suspensions.txt#L99) that this is a known issue. I even found a [master thesis](https://www.research-collection.ethz.ch/bitstream/handle/20.500.11850/447416/1/Schneider_Jo%C3%ABl.pdf) that created their own debugger for skulpt and they also have the same issue ([link ](https://webtigerjython.ethz.ch/)to their web app). I've added this issue to the known limitations in the about page for now.

